### PR TITLE
Bug fix and new types for OptionPart

### DIFF
--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -84,13 +84,17 @@ class OptionPart(with_metaclass(OptionPartMeta, Part)):
             if value is None:
                 continue
 
-            if typ == 3:
+            if typ == 1:
+                value = struct.pack('B', value)
+            elif typ == 2:
+                value = struct.pack('h', value)
+            elif typ == 3:
                 value = struct.pack('i', value)
             elif typ == 4:
                 value = struct.pack('l', value)
             elif typ == 28:
                 value = struct.pack('?', value)
-            elif typ == 29:
+            elif typ == 29 or typ == 30:
                 value = value.encode('utf-8')
                 value = struct.pack('h', len(value)) + value
             else:
@@ -109,13 +113,17 @@ class OptionPart(with_metaclass(OptionPartMeta, Part)):
                 continue
             key = cls.option_identifier[key]
 
-            if typ == 3:
+            if typ == 1:
+                value = struct.unpack('B', payload.read(1))[0]
+            elif typ == 2:
+                value = struct.unpack('h', payload.read(2))[0]
+            elif typ == 3:
                 value = struct.unpack('i', payload.read(4))[0]
             elif typ == 4:
                 value = struct.unpack('l', payload.read(8))[0]
             elif typ == 28:
                 value = struct.unpack('?', payload.read(1))[0]
-            elif typ == 29:
+            elif typ == 29 or typ == 30:
                 length = struct.unpack('h', payload.read(2))[0]
                 value = payload.read(length).decode('utf-8')
             elif typ == 24:

--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -109,9 +109,11 @@ class OptionPart(with_metaclass(OptionPartMeta, Part)):
         options = {}
         for i in iter_range(argument_count):
             key, typ = struct.unpack('bb', payload.read(2))
+
             if key not in cls.option_identifier:
-                continue
-            key = cls.option_identifier[key]
+                key = 'Unknown_%d' % key
+            else:
+                key = cls.option_identifier[key]
 
             if typ == 1:
                 value = struct.unpack('B', payload.read(1))[0]


### PR DESCRIPTION
This will add OptionPart packing and unpacking support for the types TINYINT (1), SMALLINT (2) and NSTRING (30). This will also fix Issue https://github.com/SAP/PyHDB/issues/1.

Also, unknown option keys should no longer mess with the parsing process. Before, the module would not try to parse unknown options and therefore its data was never read. That resulted in the data cursor being at the wrong position for the next option to parse.