### PR TITLE
Added 4-byte unichr compatibility for 'narrow' Python builds.

### DIFF
--- a/pyhdb/_compat.py
+++ b/pyhdb/_compat.py
@@ -32,6 +32,10 @@ else:
     unichr = chr
     iter_range = range
 
+# workaround for 'narrow' Python builds
+if sys.maxunicode <= 65535:
+    unichr = lambda n: ('\\U%08x' % n).decode('unicode-escape')
+
 def with_metaclass(meta, *bases):
     """
     Function from jinja2/_compat.py.


### PR DESCRIPTION
Bugfix for issue #4.

Most Python builds do not support wide-char unicodes and are considered "narrow" builds. These builds cannot use the `unichr` function with 4-byte integers.

This pull request provides a workaround for narrow Python builds that is described on [stackoverflow](http://stackoverflow.com/a/7107319/3086288). Basically, the function creates a '\Uxxxxxxx' string that is then decoded with `decode('unicode-escape')`.