### PR TITLE
Add 'named' parameter style

### DIFF
--- a/pyhdb/__init__.py
+++ b/pyhdb/__init__.py
@@ -24,7 +24,7 @@ from pyhdb.exceptions import *
 
 apilevel = "2.0"
 threadsafety = 2
-paramstyle = ("qmark", "named", "format")
+paramstyle = "qmark"
 
 
 def connect(host, port, user, password, autocommit=False):

--- a/pyhdb/__init__.py
+++ b/pyhdb/__init__.py
@@ -24,7 +24,7 @@ from pyhdb.exceptions import *
 
 apilevel = "2.0"
 threadsafety = 2
-paramstyle = "format"
+paramstyle = ("qmark", "named", "format")
 
 
 def connect(host, port, user, password, autocommit=False):

--- a/pyhdb/cursor.py
+++ b/pyhdb/cursor.py
@@ -35,7 +35,7 @@ def format_operation(operation, parameters=None):
         e_values = escape_values(parameters)
         try:
             operation = operation % e_values
-        except TypeError, msg:
+        except TypeError as msg:
             if str(msg) in FORMAT_OPERATION_ERRORS:
                 # Python DBAPI expects a ProgrammingError in this case
                 raise ProgrammingError(str(msg))
@@ -59,7 +59,8 @@ class PreparedStatement(object):
                 self._param_values[param[3]] = None
         else:
             # parameters by sequence
-            self._param_values = [None] * (1+len(parameters)) # sequence starts from 1, 2 ...; 0 not used
+            # sequence starts from 1, 2 ...; 0 not used
+            self._param_values = [None] * (1+len(parameters))
 
     @property
     def statement_id(self):
@@ -99,9 +100,10 @@ class PreparedStatement(object):
 
     def set_parameters(self, param_values):
         if type(param_values) is list:
-            if (len(param_values) + 1) != len (self._param_values):
+            if (len(param_values) + 1) != len(self._param_values):
                 raise ProgrammingError(
-                    "Prepared statement parameters expected %d supplied %d." % (len(self._param_values) - 1, len(param_values))
+                    "Prepared statement parameters expected %d supplied %d." % (
+                        len(self._param_values) - 1, len(param_values))
                 )
 
             for param_id, value in enumerate(param_values):
@@ -147,7 +149,7 @@ class Cursor(object):
         ).send()
 
         _result = {}
-        _result['result_metadata'] = None # not sent for INSERT
+        _result['result_metadata'] = None  # not sent for INSERT
         for _part in response.segments[0].parts:
             if _part.kind == part_kinds.STATEMENTID:
                 statement_id = _part.statement_id
@@ -201,12 +203,12 @@ class Cursor(object):
         In order to be compatible with Python's DBAPI five parameter styles
         must be supported.
 
-        paramstyle 	Meaning
+        paramstyle     Meaning
         ---------------------------------------------------------
         1) qmark       Question mark style, e.g. ...WHERE name=?
         2) numeric     Numeric, positional style, e.g. ...WHERE name=:1
         3) named       Named style, e.g. ...WHERE name=:name
-        4) format 	   ANSI C printf format codes, e.g. ...WHERE name=%s
+        4) format      ANSI C printf format codes, e.g. ...WHERE name=%s
         5) pyformat    Python extended format codes, e.g. ...WHERE name=%(name)s
 
         Hana's 'prepare statement' feature supports 1) and 2), while 4 and 5
@@ -223,7 +225,7 @@ class Cursor(object):
             # First try safer hana-style parameter expansion:
             try:
                 statement_id = self.prepare(statement)
-            except DatabaseError, msg:
+            except DatabaseError as msg:
                 # Hana expansion failed, check message to be sure of reason:
                 if 'incorrect syntax near "%"' not in str(msg):
                     # Probably some other error than related to string expansion
@@ -311,13 +313,12 @@ class Cursor(object):
             elif part.kind == part_kinds.STATEMENTCONTEXT:
                 pass
             else:
-                raise InterfaceError (
+                raise InterfaceError(
                     "Prepared select statement response, unexpected part kind %d." % part.kind
                 )
 
     def _handle_prepared_insert(self, parts):
         for part in parts:
-            print part.kind
             if part.kind == part_kinds.ROWSAFFECTED:
                 self.rowcount = part.values[0]
             elif part.kind == part_kinds.TRANSACTIONFLAGS:
@@ -325,7 +326,7 @@ class Cursor(object):
             elif part.kind == part_kinds.STATEMENTCONTEXT:
                 pass
             else:
-                raise InterfaceError (
+                raise InterfaceError(
                     "Prepared insert statement response, unexpected part kind %d." % part.kind
                 )
         self._executed = True

--- a/tests/dbapi/test_module.py
+++ b/tests/dbapi/test_module.py
@@ -24,8 +24,9 @@ def test_threadsafety():
     assert pyhdb.threadsafety == 2
 
 def test_paramstyle():
-    # TODO: Support also named format
-    assert pyhdb.paramstyle == "format"
+    assert "format" in pyhdb.paramstyle
+    assert "qmark" in pyhdb.paramstyle
+    assert "named" in pyhdb.paramstyle
 
 def test_exceptions():
     assert issubclass(pyhdb.Warning, Exception)

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -78,12 +78,24 @@ def test_format_operation_with_too_many_positional_parameters_raises():
         format_operation("INSERT INTO TEST VALUES(%s)", ('Hello World', 2))
 
 
-def test_format_operation_with_named_parameters():
+def test_format_operation_with_pyformat_parameters():
     """format_operation() is used for Python style parameter expansion"""
     assert format_operation(
         "INSERT INTO TEST VALUES(%(name)s, %(val)s)",
         {'name': 'Hello World', 'val': 2}
     ) == "INSERT INTO TEST VALUES('Hello World', 2)"
+
+
+def test_format_operation_with_qmark_parameters():
+    assert format_operation(
+        "INSERT INTO TEST VALUES(?)", ("'Hello World'",)
+    ) == "INSERT INTO TEST VALUES('''Hello World''')"
+
+
+def test_format_operation_with_named_parameters():
+    assert format_operation(
+        "INSERT INTO TEST VALUES(:hello)", dict(hello="'Hello World'")
+    ) == "INSERT INTO TEST VALUES('''Hello World''')"
 
 
 @pytest.mark.hanatest
@@ -113,12 +125,12 @@ def test_cursor_fetchall_multiple_rows(connection):
 
 # Test cases for different parameter style expansion
 #
-# paramstyle 	Meaning
+# paramstyle     Meaning
 # ---------------------------------------------------------
 # 1) qmark       Question mark style, e.g. ...WHERE name=?
 # 2) numeric     Numeric, positional style, e.g. ...WHERE name=:1
 # 3) named       Named style, e.g. ...WHERE name=:name  -> NOT IMPLEMENTED !!
-# 4) format 	   ANSI C printf format codes, e.g. ...WHERE name=%s
+# 4) format      ANSI C printf format codes, e.g. ...WHERE name=%s
 # 5) pyformat    Python extended format codes, e.g. ...WHERE name=%(name)s
 
 @pytest.mark.hanatest
@@ -303,4 +315,3 @@ def test_cursor_executemany(connection, test_table_1):
 #     ps = cursor.prepared_statement(statement_id)
 #
 #     assert ps.parameters == ((2, 4, 1, 0, '', 19, 0, 0), (1, 3, 1, 0, '', 10, 0, 0))
-


### PR DESCRIPTION
This makes it possible to use question marks and named tags as placeholders in queries, e.g.
    `cursor.execute("INSERT INTO TEST VALUES(?)", ("'Hello World'",))`
and
`cursor.execute("INSERT INTO TEST VALUES(:hello)", dict(hello="'Hello World'"))`
This fixes issue #8.
