### PR TITLE
Adding logging.conf to package data

### DIFF
--- a/pyhdb/__init__.py
+++ b/pyhdb/__init__.py
@@ -17,7 +17,7 @@ import logging
 import logging.config
 
 this_dir = os.path.dirname(__file__)
-logging.config.fileConfig(os.path.join(this_dir, 'logging.conf'))
+logging.config.fileConfig(os.path.abspath(os.path.join(this_dir, 'logging.conf')))
 
 from pyhdb.client import Connection
 from pyhdb.exceptions import *

--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,7 @@ setup(
         'Topic :: Software Development',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    package_data={
+        'pyhdb': ['logging.conf']
+    }
 )


### PR DESCRIPTION
When installing the latest version of pyhdb from github ``logging.conf`` wasn't included in the package data. This patch ensures that.