### PR TITLE
New Field for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     version=get_version(),
     license="Apache License Version 2.0",
     url="https://github.com/SAP/pyhdb/",
+    download_url="https://github.com/SAP/PyHDB/tarball/master",
     author="Christoph Heer",
     author_email="christoph.heer@sap.com",
     description="SAP HANA Database Client for Python",


### PR DESCRIPTION
Added 'download_url' field for setup.py so that PyPi gets the sources from the GitHub repo.

See http://peak.telecommunity.com/DevCenter/setuptools#making-your-package-available-for-easyinstall (Making your package available for EasyInstall)