### PR TITLE
added neo.py to connect to a HANA instance in the HANA Cloud Platform

### DIFF
--- a/pyhdb/protocol/types.py
+++ b/pyhdb/protocol/types.py
@@ -387,6 +387,7 @@ class Timestamp(Type):
 
     type_code = type_codes.TIMESTAMP
     python_type = datetime.datetime
+    _struct = struct.Struct("<HBBBBH")
 
     @classmethod
     def from_resultset(cls, payload, connection=None):
@@ -401,6 +402,17 @@ class Timestamp(Type):
     @classmethod
     def to_sql(cls, value):
         return "'%s.%s'" % (value.strftime("%Y-%m-%d %H:%M:%S"), value.microsecond)
+
+    @classmethod
+    def prepare(cls, value):
+        """Pack datetime value into proper binary format"""
+        pfield = struct.pack('b', cls.type_code)
+        millisecond = int(round(value.second * 1000 + value.microsecond / 1000.))
+        year = value.year | 0x8000  # for some unknown reasons year has to be bit-or'ed with 0x8000
+        month = value.month - 1     # for some unknown reasons HANA counts months starting from zero
+        hour = value.hour | 0x80    # for some unknown reasons hour has to be bit-or'ed with 0x80
+        pfield += cls._struct.pack(year, month, value.day, hour, value.minute, millisecond)
+        return pfield
 
 
 class MixinLobType(object):

--- a/pyhdb/protocol/types.py
+++ b/pyhdb/protocol/types.py
@@ -110,7 +110,7 @@ class _IntType(Type):
             pfield = struct.pack('b', 0)
         else:
             pfield = struct.pack('b', cls.type_code)
-            pfield += cls._struct.pack(value)
+            pfield += cls._struct.pack(int(value))
         return pfield
 
 

--- a/pyhdb/protocol/types.py
+++ b/pyhdb/protocol/types.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import absolute_import
 
+import types as py_types
 import re
 import struct
 import binascii
@@ -248,19 +250,22 @@ class String(Type):
         pfield = struct.pack('b', type_code)
         if value is None:
             # length indicator
-            pfield += struct.pack('b', 255)
+            pfield += struct.pack('B', 255)
         else:
+            if not isinstance(value, py_types.StringTypes):
+                # Value is provided e.g. as integer, but a string is actually required. Try proper casting into string:
+                value = text_type(value)
             value = value.encode('cesu-8')
             length = len(value)
             # length indicator
             if length <= 245:
-                pfield += struct.pack('b', length)
+                pfield += struct.pack('B', length)
             elif length <= 32767:
-                pfield += struct.pack('b', 246)
-                pfield += struct.pack('h', length)
+                pfield += struct.pack('B', 246)
+                pfield += struct.pack('H', length)
             else:
-                pfield += struct.pack('b', 247)
-                pfield += struct.pack('i', length)
+                pfield += struct.pack('B', 247)
+                pfield += struct.pack('I', length)
             pfield += value
         return pfield
 

--- a/tests/types/test_datetime.py
+++ b/tests/types/test_datetime.py
@@ -19,6 +19,8 @@ import pytest
 from pyhdb.protocol import types
 
 
+# ########################## Test value unpacking #####################################
+
 @pytest.mark.parametrize("input,expected", [
     (b'\x90\x0C\xD8\x59', time(16, 12, 23)),
     (b"\x00\x00\x00\x00", None),
@@ -79,3 +81,13 @@ def test_escape_timestamp(input, expected):
 ])
 def test_to_daydate(input, expected):
     assert types.Date.to_daydate(input) == expected
+
+
+# ########################## Test value packing #####################################
+
+@pytest.mark.parametrize("input,expected", [
+    (datetime(2014, 8, 25, 9, 47, 3, 2000), b'\x10\xDE\x87\x07\x19\x89\x2F\xba\x0b'),
+])
+def test_pack_timestamp(input, expected):
+        assert types.Timestamp.prepare(input) == expected
+

--- a/tests/types/test_int.py
+++ b/tests/types/test_int.py
@@ -20,6 +20,8 @@ import pytest
 from pyhdb.protocol import types
 
 
+# ########################## Test value unpacking #####################################
+
 @pytest.mark.parametrize("input,expected", [
     (b"\x01\x15\xCD\x5B\x07", 123456789),
     (b"\x01\xB1\x68\xDE\x3A", 987654321),
@@ -110,3 +112,75 @@ def test_unpack_real(input, expected):
 def test_unpack_double(input, expected):
     input = BytesIO(input)
     assert types.Double.from_resultset(input) == expected
+
+
+# ########################## Test value packing #####################################
+
+@pytest.mark.parametrize("input,expected", [
+    (123456789, b"\x01\x15\xCD\x5B\x07"),
+    ('123456789', b"\x01\x15\xCD\x5B\x07"),    # also ensure that strings are accepted
+    (u'123456789', b"\x01\x15\xCD\x5B\x07"),   # also ensure that unicodes are accepted
+    (987654321, b"\x01\xB1\x68\xDE\x3A"),
+    (None, b"\x00"),
+])
+def test_pack_int(input, expected):
+    types.Int.prepare(input) == expected
+
+
+@pytest.mark.parametrize("input,expected", [
+    (0, b"\x01\x00"),
+    (1, b"\x01\x01"),
+    (123, b"\x01\x7B"),
+    ('123', b"\x01\x7B"),
+    (u'123', b"\x01\x7B"),
+    (255, b"\x01\xFF"),
+    (None, b"\x00"),
+])
+def test_pack_tinyint(input, expected):
+    types.TinyInt.prepare(input) == expected
+
+
+@pytest.mark.parametrize("input,expected", [
+    (12345, b"\x01\x39\x30"),
+    (-12345, b"\x01\xC7\xCF"),
+    ('-12345', b"\x01\xC7\xCF"),
+    (u'-12345', b"\x01\xC7\xCF"),
+    (None, b"\x00"),
+])
+def test_pack_smallint(input, expected):
+    types.SmallInt.prepare(input) == expected
+
+
+@pytest.mark.parametrize("input,expected", [
+    (2**32, b"\x01\x00\x00\x00\x00\x01\x00\x00\x00"),
+    (-2**32, b"\x01\x00\x00\x00\x00\xFF\xFF\xFF\xFF"),
+    ('4294967296', b"\x01\x00\x00\x00\x00\xFF\xFF\xFF\xFF"),
+    (u'4294967296', b"\x01\x00\x00\x00\x00\xFF\xFF\xFF\xFF"),
+    (None, b"\x00"),
+])
+def test_pack_bigint(input, expected):
+    types.BigInt.prepare(input) == expected
+
+
+#
+# NOTE: packing for floats and doubles not yet implementd
+#
+# @pytest.mark.parametrize("input,expected", [
+#     (float("10.119999885559082"), b"\x85\xEB\x21\x41"),
+#     (float("-10.119999885559082"), b"\x85\xEB\x21\xC1"),
+#     ("-10.119999885559082", b"\x85\xEB\x21\xC1"),
+#     (u"-10.119999885559082", b"\x85\xEB\x21\xC1"),
+#     (None, b"\xFF\xFF\xFF\xFF"),
+# ])
+# def test_pack_real(input, expected):
+#     types.Real.prepare(input) == expected
+#
+#
+# @pytest.mark.parametrize("input,expected", [
+#     (float("10.12"), b"\x3D\x0A\xD7\xA3\x70\x3D\x24\x40"),
+#     (float("-10.12"), b"\x3D\x0A\xD7\xA3\x70\x3D\x24\xC0"),
+#     (None, b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"),
+# ])
+# def test_pack_double(input, expected):
+#     types.Double.prepare(input) == expected
+#

--- a/tests/types/test_string.py
+++ b/tests/types/test_string.py
@@ -22,6 +22,8 @@ from pyhdb.exceptions import InterfaceError
 from pyhdb.compat import byte_type
 
 
+# ########################## Test value unpacking #####################################
+
 @pytest.mark.parametrize("input,expected", [
     (b"\xFF", None),
     (b"\x0B\x48\x65\x6C\x6C\x6F\x20\x57\x6F\x72\x6C\x64", "Hello World"),
@@ -79,3 +81,28 @@ def test_unpack_very_long_binary():
 ])
 def test_escape_binary(input, expected):
     assert types.Binary.to_sql(input) == expected
+
+
+# ########################## Test value packing #####################################
+
+@pytest.mark.parametrize("input,expected", [
+    (None, b"\x08\xFF", ),
+    ('123', b"\x08\x03123"),       # convert an integer into its string representation
+    ("Hello World", b"\x08\x0B\x48\x65\x6C\x6C\x6F\x20\x57\x6F\x72\x6C\x64"),
+])
+def test_pack_string(input, expected):
+    assert types.String.prepare(input) == expected
+
+
+def test_pack_long_string():
+    text = b'\xe6\x9c\xb1' * 3500
+    expected = b"\x08\xF6\x04\x29" + text
+    assert types.String.prepare(text.decode('cesu-8')) == expected
+
+
+def test_pack_very_long_string():
+    text = b'\xe6\x9c\xb1' * 35000
+    expected = b"\x08\xF7\x28\x9a\x01\x00" + text
+    assert types.String.prepare(text.decode('cesu-8')) == expected
+
+


### PR DESCRIPTION
requires 'pexpect' module to be installed (not added to setup.py yet, but we could....)
Run
    pip install pexcect 
before using it.
In the top of the neo.py module you find extended information on how to use it.