### PR TITLE
fix BigInt decoding

### DIFF
--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -756,7 +756,7 @@ class OptionPart(with_metaclass(OptionPartMeta, Part)):
             elif typ == 3:
                 value = struct.pack('i', value)
             elif typ == 4:
-                value = struct.pack('l', value)
+                value = struct.pack('q', value)
             elif typ == 28:
                 value = struct.pack('?', value)
             elif typ == 29 or typ == 30:
@@ -787,7 +787,7 @@ class OptionPart(with_metaclass(OptionPartMeta, Part)):
             elif typ == 3:
                 value = struct.unpack('i', payload.read(4))[0]
             elif typ == 4:
-                value = struct.unpack('l', payload.read(8))[0]
+                value = struct.unpack('q', payload.read(8))[0]
             elif typ == 28:
                 value = struct.unpack('?', payload.read(1))[0]
             elif typ == 29 or typ == 30:

--- a/pyhdb/protocol/types.py
+++ b/pyhdb/protocol/types.py
@@ -142,7 +142,7 @@ class Int(_IntType):
 class BigInt(_IntType):
 
     type_code = type_codes.BIGINT
-    _struct = struct.Struct("l")
+    _struct = struct.Struct("q")
 
 
 class Decimal(Type):


### PR DESCRIPTION
BigInt was parsed as 32bit long instead of 64bit longlong