### PR TITLE
logging configuration in library

### DIFF
--- a/pyhdb/__init__.py
+++ b/pyhdb/__init__.py
@@ -17,7 +17,6 @@ import logging
 import logging.config
 
 this_dir = os.path.dirname(__file__)
-logging.config.fileConfig(os.path.join(this_dir, 'logging.conf'))
 
 from pyhdb.exceptions import *
 from pyhdb.connection import Connection


### PR DESCRIPTION
if no configuration file provided in some cases, pyHDB will reset all logging settings in application to default. So it is better to avoid any logging configuration in library.