### PR TITLE
Fix LOB return values of stored procedures with length > 1024

### DIFF
--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -231,7 +231,7 @@ class OutputParameters(Part):
         for param in parameters_metadata:
             # Unpack OUT or INOUT parameters' values
             if param.iotype != parameter_direction.IN:
-                values.append( by_type_code[param.datatype].from_resultset(self.payload) )
+                values.append( by_type_code[param.datatype].from_resultset(self.payload, connection) )
         yield tuple(values)
 
 


### PR DESCRIPTION
This fixes an error that occurred when trying to call `.read()` on a LOB object that was bound to an OUT parameter of a stored procedure. Specifically, the `_connection` attribute of the LOB object defaulted to `None`.
