### PR TITLE
Let fetch return resultRow & support named style parameters

### DIFF
--- a/pyhdb/cursor.py
+++ b/pyhdb/cursor.py
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
 import collections
 ###
 from pyhdb.protocol.message import RequestMessage
 from pyhdb.protocol.segments import RequestSegment
-from pyhdb.protocol.types import escape_values, by_type_code
+from pyhdb.protocol.types import by_type_code
 from pyhdb.protocol.parts import Command, FetchSize, ResultSetId, StatementId, Parameters, WriteLobRequest
 from pyhdb.protocol.constants import message_types, function_codes, part_kinds
-from pyhdb.exceptions import ProgrammingError, InterfaceError, DatabaseError
+from pyhdb.exceptions import ProgrammingError, InterfaceError
 from pyhdb.compat import izip
 from pyhdb.resultrow import ResultRow
 
@@ -29,20 +29,33 @@ FORMAT_OPERATION_ERRORS = [
 ]
 
 
-def format_operation(operation, parameters=None):
-    if parameters is not None:
-        e_values = escape_values(parameters)
-        try:
-            operation = operation % e_values
-        except TypeError as msg:
-            if str(msg) in FORMAT_OPERATION_ERRORS:
-                # Python DBAPI expects a ProgrammingError in this case
-                raise ProgrammingError(str(msg))
-            else:
-                # some other error message appeared, so just reraise exception:
-                raise
-    return operation
 
+_NAMED_PARAM = re.compile(r":([a-zA-Z0-9_]+)")
+
+
+def format_named_query(operation, parameters=None):
+    # replace named with question marks
+    markers = _NAMED_PARAM.findall(operation)
+
+    if parameters is None:
+        if len(markers) > 0:
+            raise ProgrammingError(0, "%d variables should be bound, but 0 variables given : %s"
+                                 % (len(markers), operation))
+        else:
+            return (operation, ())
+
+    param_values = []
+    for marker in markers:
+        if marker in parameters:
+            param_values.append(parameters[marker])
+        else:
+            raise ProgrammingError(0, ":%s is not set" % (marker,))
+    qmark_sql = _NAMED_PARAM.sub('?', operation)
+    if qmark_sql.count('?') != len(param_values):
+        raise ProgrammingError(0, "%d variables should be bound, but only %d variables given : %s"
+                                 % (qmark_sql.count('?'), len(param_values), operation))
+
+    return (qmark_sql, tuple(param_values))
 
 class PreparedStatement(object):
     """Reference object to a prepared statement including parameter (meta) data"""
@@ -238,7 +251,7 @@ class Cursor(object):
         :returns: this cursor
 
         In order to be compatible with Python's DBAPI five parameter styles
-        must be supported.
+        can be supported.
 
         paramstyle	Meaning
         ---------------------------------------------------------
@@ -248,9 +261,9 @@ class Cursor(object):
         4) format      ANSI C printf format codes, e.g. ...WHERE name=%s
         5) pyformat    Python extended format codes, e.g. ...WHERE name=%(name)s
 
-        Hana's 'prepare statement' feature supports 1) and 2), while 4 and 5
-        are handle by Python's own string expansion mechanism.
-        Note that case 3 is not yet supported by this method!
+        Hana's 'prepare statement' feature supports 1) and 2),
+        while 3) is is converted into a qmark statement.
+        Case 4) and 5) are not supported.
         """
         self._check_closed()
 
@@ -267,22 +280,42 @@ class Cursor(object):
         :param parameters: a nested list/tuple of parameters for multiple rows
         :returns: this cursor
         """
-        # First try safer hana-style parameter expansion:
-        try:
-            statement_id = self.prepare(statement)
-        except DatabaseError as msg:
-            # Hana expansion failed, check message to be sure of reason:
-            if 'incorrect syntax near "%"' not in str(msg):
-                # Probably some other error than related to string expansion -> raise an error
-                raise
-            # Statement contained percentage char, so perform Python style parameter expansion:
-            for row_params in parameters:
-                operation = format_operation(statement, row_params)
-                self._execute_direct(operation)
+        if not parameters:
+            return self._execute_direct(statement)
+
+        # format statement and parameters
+        elif isinstance(parameters, (list, tuple)):
+            formated_statement = statement
+            formated_parameters = []
+
+            # named style
+            if isinstance(parameters[0], dict):
+                for parameters in parameters:
+                    # mixing of styles not allowed
+                    if isinstance(parameters, dict):
+                        formated_statement, param_values = format_named_query(statement, parameters)
+                        formated_parameters.append(param_values)
+                    else:
+                        raise ProgrammingError("Only dictionary is allowed in the sequence(tuple, list) of parameters if named sytle parameters are used.")
+
+            # numeric/qmark style
+            elif isinstance(parameters[0], (list, tuple)):
+                for parameters in parameters:
+                    # mixing of styles not allowed
+                    if isinstance(parameters, (list, tuple)):
+                        formated_parameters.append(parameters)
+                    else:
+                        raise ProgrammingError("A tuple or a list is allowed in the sequence(tuple, list) of parameters if qmark or numeric style parameters are used.")
+            else:
+                raise ProgrammingError("A tuple, dict or a list is allowed in the sequence(tuple, list) of parameters.")
         else:
-            # Continue with Hana style statement execution:
-            prepared_statement = self.get_prepared_statement(statement_id)
-            self.execute_prepared(prepared_statement, parameters)
+            raise ProgrammingError("Second parameter should be a tuple or a list of parameters")
+
+        # Continue with prepared statement execution:
+        statement_id = self.prepare(formated_statement)
+        prepared_statement = self.get_prepared_statement(statement_id)
+
+        self.execute_prepared(prepared_statement, formated_parameters)
         # Return cursor object:
         return self
 

--- a/pyhdb/resultrow.py
+++ b/pyhdb/resultrow.py
@@ -1,0 +1,59 @@
+import types
+
+class ResultRow(object):
+    """
+    Result Row returned by fetch*()
+    """
+    def __init__(self, column_names=(), column_values=()):
+        self.__update(column_names, column_values)
+
+    def __repr__(self):
+        return str(self.column_values)
+
+    def __update(self, column_names, column_values):
+        self.column_names = list(column_names)
+        self.column_values = column_values
+
+    def __setitem__(self, key, value):
+        if type(key) == types.IntType:
+            self.column_values[key] = value
+        elif type(key) == types.StringType:
+            try:
+                ind = self.column_names.index(key.upper())
+                self.column_values[ind] = value
+            except ValueError:
+                raise KeyError("\'%s\' is not found" % key.upper())
+        else:
+            raise TypeError("%s is not supported as a key" % str(type(key)))
+
+    def __getitem__(self, key):
+        if type(key) == types.IntType:
+            return self.column_values[key]
+        elif type(key) == types.SliceType:
+            return self.column_values[key.start:key.stop:key.step]
+        elif type(key) == types.StringType:
+            try:
+                ind = self.column_names.index(key.upper())
+                return self.column_values[ind]
+            except ValueError:
+                raise KeyError("\'%s\' is not found" % key.upper())
+        else:
+            raise TypeError("%s is not supported as a key" % str(type(key)))
+
+    def __len__(self):
+        return len(self.column_values)
+
+
+    def __iter__(self):
+        for value in self.column_values:
+            yield value
+
+    def __cmp__(self, other):
+        if not isinstance(other, ResultRow):
+            raise TypeError("%s is not a result row fetched by pyhdb" % (other,))
+        if self.column_values < other.column_values:
+            return -1
+        elif self.column_values == other.column_values:
+            return 0
+        else:  # self > other
+            return 1

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -21,7 +21,7 @@ def exists_table(connection, table):
     :returns: bool
     """
     cursor = connection.cursor()
-    cursor.execute('SELECT 1 FROM "SYS"."TABLES" WHERE "TABLE_NAME" = %s', (table,))
+    cursor.execute('SELECT 1 FROM "SYS"."TABLES" WHERE "TABLE_NAME" = ?', (table,))
     return cursor.fetchone() is not None
 
 

--- a/tests/test_call_stored.py
+++ b/tests/test_call_stored.py
@@ -19,7 +19,7 @@ import pytest
 import tests.helper
 
 from tests.helper import procedure_add2_fixture, procedure_with_result_fixture
-
+from pyhdb.resultrow import ResultRow
 # #############################################################################################################
 #                         Basic Stored Procedure test
 # #############################################################################################################
@@ -36,7 +36,7 @@ def test_PROC_ADD2(connection, procedure_add2_fixture):
     ps = cursor.get_prepared_statement(psid)
     cursor.execute_prepared(ps, [params])
     result = cursor.fetchall()
-    assert result == [(7, 'A')]
+    assert result == [ResultRow((), (7, 'A'))]
 
 @pytest.mark.hanatest
 def test_proc_with_results(connection, procedure_with_result_fixture):
@@ -50,6 +50,6 @@ def test_proc_with_results(connection, procedure_with_result_fixture):
     cursor.execute_prepared(ps, [{'OUTVAR': 0}])
     result = cursor.fetchall()
 
-    assert result == [(2015,)]
+    assert result == [ResultRow((), (2015,))]
 
     cursor.close()

--- a/tests/test_dummy_sql.py
+++ b/tests/test_dummy_sql.py
@@ -82,7 +82,7 @@ def test_dummy_sql_to_time(connection):
     now = datetime.datetime.now().time()
 
     cursor = connection.cursor()
-    cursor.execute("SELECT to_time(%s) FROM DUMMY", (now,))
+    cursor.execute("SELECT to_time(?) FROM DUMMY", (now,))
 
     result = cursor.fetchone()
 
@@ -104,7 +104,7 @@ def test_dummy_sql_to_date(connection):
     today = datetime.date.today()
 
     cursor = connection.cursor()
-    cursor.execute("SELECT to_date(%s) FROM DUMMY", (today,))
+    cursor.execute("SELECT to_date(?) FROM DUMMY", (today,))
 
     result = cursor.fetchone()
     assert result[0] == today
@@ -125,7 +125,7 @@ def test_dummy_sql_to_timestamp(connection):
     now = now.replace(microsecond=123000)
 
     cursor = connection.cursor()
-    cursor.execute("SELECT to_timestamp(%s) FROM DUMMY", (now,))
+    cursor.execute("SELECT to_timestamp(?) FROM DUMMY", (now,))
 
     result = cursor.fetchone()
     assert result[0] == now

--- a/tests/test_dummy_sql.py
+++ b/tests/test_dummy_sql.py
@@ -17,7 +17,7 @@ import datetime
 from decimal import Decimal, getcontext
 
 import pytest
-
+from pyhdb.resultrow import ResultRow
 
 @pytest.mark.hanatest
 def test_dummy_sql_int(connection):
@@ -25,7 +25,7 @@ def test_dummy_sql_int(connection):
     cursor.execute("SELECT 1 FROM DUMMY")
 
     result = cursor.fetchone()
-    assert result == (1,)
+    assert result == ResultRow((), (1,))
 
 
 @pytest.mark.hanatest
@@ -36,7 +36,7 @@ def test_dummy_sql_decimal(connection):
     cursor.execute("SELECT -312313212312321.1245678910111213142 FROM DUMMY")
 
     result = cursor.fetchone()
-    assert result == (Decimal('-312313212312321.1245678910111213142'),)
+    assert result == ResultRow((), (Decimal('-312313212312321.1245678910111213142'),))
 
 
 @pytest.mark.hanatest
@@ -45,18 +45,18 @@ def test_dummy_sql_string(connection):
     cursor.execute("SELECT 'Hello World' FROM DUMMY")
 
     result = cursor.fetchone()
-    assert result == ("Hello World",)
+    assert result == ResultRow((), ("Hello World",))
 
 
 @pytest.mark.hanatest
 def test_dummy_sql_long_string(connection):
-    test_string = '%030x' % random.randrange(16**300)
+    test_string = '%030x' % random.randrange(16 ** 300)
 
     cursor = connection.cursor()
     cursor.execute("SELECT '%s' FROM DUMMY" % test_string)
 
     result = cursor.fetchone()
-    assert result == (test_string,)
+    assert result == ResultRow((), (test_string,))
 
 
 @pytest.mark.hanatest
@@ -65,7 +65,7 @@ def test_dummy_sql_binary(connection):
     cursor.execute("SELECT X'FF00FFA3B5' FROM DUMMY")
 
     result = cursor.fetchone()
-    assert result == (b"\xFF\x00\xFF\xA3\xB5",)
+    assert result == ResultRow((), (b"\xFF\x00\xFF\xA3\xB5",))
 
 
 @pytest.mark.hanatest

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -41,7 +41,7 @@ class TestIsolationBetweenConnections(object):
 
         cursor1 = connection_1.cursor()
         cursor1.execute(
-            'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
+            'INSERT INTO PYHDB_TEST_1 VALUES(?)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
         assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
@@ -66,7 +66,7 @@ class TestIsolationBetweenConnections(object):
 
         cursor1 = connection_1.cursor()
         cursor1.execute(
-            'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
+            'INSERT INTO PYHDB_TEST_1 VALUES(?)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
         assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
@@ -91,7 +91,7 @@ class TestIsolationBetweenConnections(object):
 
         cursor1 = connection_1.cursor()
         cursor1.execute(
-            'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
+            'INSERT INTO PYHDB_TEST_1 VALUES(?)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
         assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
@@ -102,7 +102,7 @@ class TestIsolationBetweenConnections(object):
 
     def test_select_for_update(self, connection, test_table):
         cursor = connection.cursor()
-        cursor.execute("INSERT INTO PYHDB_TEST_1 VALUES(%s)", ('test',))
+        cursor.execute("INSERT INTO PYHDB_TEST_1 VALUES(?)", ('test',))
         connection.commit()
 
         cursor.execute("SELECT * FROM PYHDB_TEST_1 FOR UPDATE")

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -16,7 +16,7 @@ import pytest
 
 import pyhdb
 import tests.helper
-
+from pyhdb.resultrow import ResultRow
 TABLE = 'PYHDB_TEST_1'
 TABLE_FIELDS = 'TEST VARCHAR(255)'
 
@@ -44,7 +44,7 @@ class TestIsolationBetweenConnections(object):
             'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor1.fetchall() == [('connection_1',)]
+        assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
 
         cursor2 = connection_2.cursor()
         cursor2.execute("SELECT * FROM PYHDB_TEST_1")
@@ -53,7 +53,7 @@ class TestIsolationBetweenConnections(object):
         connection_1.commit()
 
         cursor2.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor2.fetchall() == [('connection_1',)]
+        assert cursor2.fetchall() == [ResultRow((), ('connection_1',))]
 
     def test_rollback(self, request, hana_system, test_table):
         connection_1 = pyhdb.connect(*hana_system)
@@ -69,7 +69,7 @@ class TestIsolationBetweenConnections(object):
             'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor1.fetchall() == [('connection_1',)]
+        assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
 
         cursor2 = connection_2.cursor()
         cursor2.execute("SELECT * FROM PYHDB_TEST_1")
@@ -94,11 +94,11 @@ class TestIsolationBetweenConnections(object):
             'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor1.fetchall() == [('connection_1',)]
+        assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
 
         cursor2 = connection_2.cursor()
         cursor2.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor2.fetchall() == [('connection_1',)]
+        assert cursor2.fetchall() == [ResultRow((), ('connection_1',))]
 
     def test_select_for_update(self, connection, test_table):
         cursor = connection.cursor()
@@ -106,5 +106,5 @@ class TestIsolationBetweenConnections(object):
         connection.commit()
 
         cursor.execute("SELECT * FROM PYHDB_TEST_1 FOR UPDATE")
-        assert cursor.fetchall() == [('test',)]
+        assert cursor.fetchall() == [ResultRow((), ('test',))]
 


### PR DESCRIPTION
ResultRow objects enables one to acces elements either
using indices or using their column names.


Add support of keyword parameter style and
remove support of format parameter style.

Support of format parameter style is removed, because they do not lead
to prepared statements, instead the parameters are inserted
as strings. Thus, there are no benefits of using this style of prepared
statement style, neither regarding security nor performance.

To not let one think using format style parameters leads to prepared statements,
the support of this style should be removed.