### PR TITLE
Support of keyword style prepared statement

### DIFF
--- a/pyhdb/cursor.py
+++ b/pyhdb/cursor.py
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
 import collections
 ###
 from pyhdb.protocol.message import RequestMessage
 from pyhdb.protocol.segments import RequestSegment
-from pyhdb.protocol.types import escape_values, by_type_code
+from pyhdb.protocol.types import by_type_code
 from pyhdb.protocol.parts import Command, FetchSize, ResultSetId, StatementId, Parameters, WriteLobRequest
 from pyhdb.protocol.constants import message_types, function_codes, part_kinds
-from pyhdb.exceptions import ProgrammingError, InterfaceError, DatabaseError
+from pyhdb.exceptions import ProgrammingError, InterfaceError
 from pyhdb.compat import izip
 
 FORMAT_OPERATION_ERRORS = [
@@ -28,20 +28,33 @@ FORMAT_OPERATION_ERRORS = [
 ]
 
 
-def format_operation(operation, parameters=None):
-    if parameters is not None:
-        e_values = escape_values(parameters)
-        try:
-            operation = operation % e_values
-        except TypeError as msg:
-            if str(msg) in FORMAT_OPERATION_ERRORS:
-                # Python DBAPI expects a ProgrammingError in this case
-                raise ProgrammingError(str(msg))
-            else:
-                # some other error message appeared, so just reraise exception:
-                raise
-    return operation
 
+_NAMED_PARAM = re.compile(r":([a-zA-Z0-9_]+)")
+
+
+def format_named_query(operation, parameters=None):
+    # replace named with question marks
+    markers = _NAMED_PARAM.findall(operation)
+
+    if parameters is None:
+        if len(markers) > 0:
+            raise ProgrammingError(0, "%d variables should be bound, but 0 variables given : %s"
+                                 % (len(markers), operation))
+        else:
+            return (operation, ())
+
+    param_values = []
+    for marker in markers:
+        if marker in parameters:
+            param_values.append(parameters[marker])
+        else:
+            raise ProgrammingError(0, ":%s is not set" % (marker,))
+    qmark_sql = _NAMED_PARAM.sub('?', operation)
+    if qmark_sql.count('?') != len(param_values):
+        raise ProgrammingError(0, "%d variables should be bound, but only %d variables given : %s"
+                                 % (qmark_sql.count('?'), len(param_values), operation))
+
+    return (qmark_sql, tuple(param_values))
 
 class PreparedStatement(object):
     """Reference object to a prepared statement including parameter (meta) data"""
@@ -237,7 +250,7 @@ class Cursor(object):
         :returns: this cursor
 
         In order to be compatible with Python's DBAPI five parameter styles
-        must be supported.
+        can be supported.
 
         paramstyle	Meaning
         ---------------------------------------------------------
@@ -247,9 +260,9 @@ class Cursor(object):
         4) format      ANSI C printf format codes, e.g. ...WHERE name=%s
         5) pyformat    Python extended format codes, e.g. ...WHERE name=%(name)s
 
-        Hana's 'prepare statement' feature supports 1) and 2), while 4 and 5
-        are handle by Python's own string expansion mechanism.
-        Note that case 3 is not yet supported by this method!
+        Hana's 'prepare statement' feature supports 1) and 2),
+        while 3) is is converted into a qmark statement.
+        Case 4) and 5) are not supported.
         """
         self._check_closed()
 
@@ -266,22 +279,42 @@ class Cursor(object):
         :param parameters: a nested list/tuple of parameters for multiple rows
         :returns: this cursor
         """
-        # First try safer hana-style parameter expansion:
-        try:
-            statement_id = self.prepare(statement)
-        except DatabaseError as msg:
-            # Hana expansion failed, check message to be sure of reason:
-            if 'incorrect syntax near "%"' not in str(msg):
-                # Probably some other error than related to string expansion -> raise an error
-                raise
-            # Statement contained percentage char, so perform Python style parameter expansion:
-            for row_params in parameters:
-                operation = format_operation(statement, row_params)
-                self._execute_direct(operation)
+        if not parameters:
+            return self._execute_direct(statement)
+
+        # format statement and parameters
+        elif isinstance(parameters, (list, tuple)):
+            formated_statement = statement
+            formated_parameters = []
+
+            # named style
+            if isinstance(parameters[0], dict):
+                for parameters in parameters:
+                    # mixing of styles not allowed
+                    if isinstance(parameters, dict):
+                        formated_statement, param_values = format_named_query(statement, parameters)
+                        formated_parameters.append(param_values)
+                    else:
+                        raise ProgrammingError("Only dictionary is allowed in the sequence(tuple, list) of parameters if named sytle parameters are used.")
+
+            # numeric/qmark style
+            elif isinstance(parameters[0], (list, tuple)):
+                for parameters in parameters:
+                    # mixing of styles not allowed
+                    if isinstance(parameters, (list, tuple)):
+                        formated_parameters.append(parameters)
+                    else:
+                        raise ProgrammingError("A tuple or a list is allowed in the sequence(tuple, list) of parameters if qmark or numeric style parameters are used.")
+            else:
+                raise ProgrammingError("A tuple, dict or a list is allowed in the sequence(tuple, list) of parameters.")
         else:
-            # Continue with Hana style statement execution:
-            prepared_statement = self.get_prepared_statement(statement_id)
-            self.execute_prepared(prepared_statement, parameters)
+            raise ProgrammingError("Second parameter should be a tuple or a list of parameters")
+
+        # Continue with prepared statement execution:
+        statement_id = self.prepare(formated_statement)
+        prepared_statement = self.get_prepared_statement(statement_id)
+
+        self.execute_prepared(prepared_statement, formated_parameters)
         # Return cursor object:
         return self
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -21,7 +21,7 @@ def exists_table(connection, table):
     :returns: bool
     """
     cursor = connection.cursor()
-    cursor.execute('SELECT 1 FROM "SYS"."TABLES" WHERE "TABLE_NAME" = %s', (table,))
+    cursor.execute('SELECT 1 FROM "SYS"."TABLES" WHERE "TABLE_NAME" = ?', (table,))
     return cursor.fetchone() is not None
 
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -15,7 +15,7 @@
 import pytest
 from decimal import Decimal
 
-from pyhdb.cursor import format_operation
+from pyhdb.cursor import format_named_query
 from pyhdb.exceptions import ProgrammingError, IntegrityError
 import tests.helper
 
@@ -50,34 +50,20 @@ def content_table_1(request, connection):
 def test_format_operation_without_parameters(parameters):
     """Test that providing no parameter produces correct result."""
     operation = "SELECT * FROM TEST WHERE fuu = 'bar'"
-    assert format_operation(operation, parameters) == operation
-
-
-def test_format_operation_with_positional_parameters():
-    """Test that correct number of parameters produces correct result."""
-    assert format_operation(
-        "INSERT INTO TEST VALUES(%s, %s)", ('Hello World', 2)
-    ) == "INSERT INTO TEST VALUES('Hello World', 2)"
-
-
-def test_format_operation_with_too_few_positional_parameters_raises():
-    """Test that providing too few parameters raises exception"""
-    with pytest.raises(ProgrammingError):
-        format_operation("INSERT INTO TEST VALUES(%s, %s)", ('Hello World',))
-
-
-def test_format_operation_with_too_many_positional_parameters_raises():
-    """Test that providing too many parameters raises exception"""
-    with pytest.raises(ProgrammingError):
-        format_operation("INSERT INTO TEST VALUES(%s)", ('Hello World', 2))
+    assert format_named_query(operation, parameters) == (operation, ())
 
 
 def test_format_operation_with_named_parameters():
-    """format_operation() is used for Python style parameter expansion"""
-    assert format_operation(
-        "INSERT INTO TEST VALUES(%(name)s, %(val)s)",
-        {'name': 'Hello World', 'val': 2}
-    ) == "INSERT INTO TEST VALUES('Hello World', 2)"
+    """Test that correct number of parameters produces correct result."""
+    assert format_named_query(
+        "INSERT INTO TEST VALUES(:st, :in)", {'st':'Hello World', 'in': 2}
+    ) == ("INSERT INTO TEST VALUES(?, ?)", ('Hello World', 2))
+
+
+def test_format_operation_with_too_few_named_parameters_raises():
+    """Test that providing too few parameters raises exception"""
+    with pytest.raises(ProgrammingError):
+        format_named_query("INSERT INTO TEST VALUES(:st, :in)", {'st':'Hello World'})
 
 
 @pytest.mark.hanatest
@@ -144,26 +130,12 @@ def test_cursor_execute_with_params2(connection, test_table_1, content_table_1):
 
 
 @pytest.mark.hanatest
-def test_cursor_execute_with_params4(connection, test_table_1, content_table_1):
-    """Test format (positional) parameter expansion style"""
-    # Uses prepare_operation method
-    cursor = connection.cursor()
-
-    sql = 'select test from PYHDB_TEST_1 where test=%s'
-    # correct way:
-    assert cursor.execute(sql, ['row2']).fetchall() == [('row2',)]
-    # invalid - extra unexpected parameter
-    with pytest.raises(ProgrammingError):
-        cursor.execute(sql, ['row2', 'extra']).fetchall()
-
-
-@pytest.mark.hanatest
 def test_cursor_execute_with_params5(connection, test_table_1, content_table_1):
-    """Test pyformat (named) parameter expansion style"""
+    """Test named parameter expansion style"""
     # Note: use fetchall() to check that only one row gets returned
     cursor = connection.cursor()
 
-    sql = 'select test from {} where test=%(test)s'.format(TABLE)
+    sql = 'select test from {} where test=:test'.format(TABLE)
     # correct way:
     assert cursor.execute(sql, {'test': 'row2'}).fetchall() == [('row2',)]
     # also correct way, additional dict value should just be ignored
@@ -247,14 +219,14 @@ def test_cursor_description_after_execution(connection):
 
 
 @pytest.mark.hanatest
-def test_cursor_executemany_python_expansion(connection, test_table_1):
+def test_cursor_executemany_named_expansion(connection, test_table_1):
     cursor = connection.cursor()
 
     cursor.executemany(
-        "INSERT INTO {} VALUES(%s)".format(TABLE),
+        "INSERT INTO {} VALUES(:test)".format(TABLE),
         (
-            ("Statement 1",),
-            ("Statement 2",)
+            {"test":"Statement 1"},
+            {"test":"Statement 2"}
         )
     )
 
@@ -278,6 +250,51 @@ def test_cursor_executemany_hana_expansion(connection, test_table_1):
     cursor.execute("SELECT * FROM %s" % TABLE)
     result = cursor.fetchall()
     assert result == [('Statement 1',), ('Statement 2',)]
+
+@pytest.mark.hanatest
+def test_cursor_executemany_mixed_list_tuple(connection, test_table_1):
+    cursor = connection.cursor()
+
+    cursor.executemany(
+        "INSERT INTO %s VALUES(:1)" % TABLE,
+        (
+            ("Statement 1",),
+            ["Statement 2"]
+        )
+    )
+
+    cursor.execute("SELECT * FROM %s" % TABLE)
+    result = cursor.fetchall()
+    assert len(result) == 2
+    assert result[0] == ('Statement 1',)
+    assert result[1] == ('Statement 2',)
+
+
+@pytest.mark.hanatest
+def test_cursor_executemany_mixed_list_dict(connection, test_table_1):
+    cursor = connection.cursor()
+
+    with pytest.raises(ProgrammingError):
+        cursor.executemany(
+            "INSERT INTO %s VALUES(:1)" % TABLE,
+            (
+                ["Statement 1"],
+                {"test":"Statement 2"}
+            )
+        )
+
+@pytest.mark.hanatest
+def test_cursor_executemany_mixed_list_dict2(connection, test_table_1):
+    cursor = connection.cursor()
+
+    with pytest.raises(ProgrammingError):
+        cursor.executemany(
+            "INSERT INTO %s VALUES(:test)" % TABLE,
+            (
+                {"test":"Statement 2"},
+                ["Statement 1"]
+            )
+        )
 
 @pytest.mark.hanatest
 def test_IntegrityError_on_unique_constraint_violation(connection, test_table_1):

--- a/tests/test_dummy_sql.py
+++ b/tests/test_dummy_sql.py
@@ -82,7 +82,7 @@ def test_dummy_sql_to_time(connection):
     now = datetime.datetime.now().time()
 
     cursor = connection.cursor()
-    cursor.execute("SELECT to_time(%s) FROM DUMMY", (now,))
+    cursor.execute("SELECT to_time(?) FROM DUMMY", (now,))
 
     result = cursor.fetchone()
 
@@ -104,7 +104,7 @@ def test_dummy_sql_to_date(connection):
     today = datetime.date.today()
 
     cursor = connection.cursor()
-    cursor.execute("SELECT to_date(%s) FROM DUMMY", (today,))
+    cursor.execute("SELECT to_date(?) FROM DUMMY", (today,))
 
     result = cursor.fetchone()
     assert result[0] == today
@@ -125,7 +125,7 @@ def test_dummy_sql_to_timestamp(connection):
     now = now.replace(microsecond=123000)
 
     cursor = connection.cursor()
-    cursor.execute("SELECT to_timestamp(%s) FROM DUMMY", (now,))
+    cursor.execute("SELECT to_timestamp(?) FROM DUMMY", (now,))
 
     result = cursor.fetchone()
     assert result[0] == now

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -41,7 +41,7 @@ class TestIsolationBetweenConnections(object):
 
         cursor1 = connection_1.cursor()
         cursor1.execute(
-            'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
+            'INSERT INTO PYHDB_TEST_1 VALUES(?)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
         assert cursor1.fetchall() == [('connection_1',)]
@@ -66,7 +66,7 @@ class TestIsolationBetweenConnections(object):
 
         cursor1 = connection_1.cursor()
         cursor1.execute(
-            'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
+            'INSERT INTO PYHDB_TEST_1 VALUES(?)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
         assert cursor1.fetchall() == [('connection_1',)]
@@ -91,7 +91,7 @@ class TestIsolationBetweenConnections(object):
 
         cursor1 = connection_1.cursor()
         cursor1.execute(
-            'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
+            'INSERT INTO PYHDB_TEST_1 VALUES(?)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
         assert cursor1.fetchall() == [('connection_1',)]
@@ -102,7 +102,7 @@ class TestIsolationBetweenConnections(object):
 
     def test_select_for_update(self, connection, test_table):
         cursor = connection.cursor()
-        cursor.execute("INSERT INTO PYHDB_TEST_1 VALUES(%s)", ('test',))
+        cursor.execute("INSERT INTO PYHDB_TEST_1 VALUES(?)", ('test',))
         connection.commit()
 
         cursor.execute("SELECT * FROM PYHDB_TEST_1 FOR UPDATE")


### PR DESCRIPTION
Add support of keyword parameter style and
remove support of format parameter style.

Support of format parameter style is removed, because they do not lead
to prepared statements, instead the parameters are inserted
as strings. Thus, there are no benefits of using this style of prepared
statement style, neither regarding security nor performance.

To not let one think using format style parameters leads to prepared statements,
the support of this style should be removed.