### PR TITLE
fix for allowing None -> null in executemany

### DIFF
--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -496,6 +496,7 @@ class Parameters(Part):
 
                 if value is None:
                     pfield = types.NoneType.prepare(type_code)
+                    type_code = 0
                 elif type_code in types.String.type_code:
                     pfield = _DataType.prepare(value, type_code)
                 else:


### PR DESCRIPTION
Maybe not the ideal solution to this problem. But this is what allowed me to use "executemany" function with None mapping to null entries. Otherwise it will break.
