### PR TITLE
Truncate (instead of round) microseconds to milliseconds.

### DIFF
--- a/pyhdb/protocol/types.py
+++ b/pyhdb/protocol/types.py
@@ -444,7 +444,7 @@ class Time(Type):
                 value = datetime.datetime.strptime(value, "%H:%M:%S.%f")
             else:
                 value = datetime.datetime.strptime(value, "%H:%M:%S")
-        millisecond = int(round(value.second * 1000 + value.microsecond / 1000.))
+        millisecond = value.second * 1000 + value.microsecond // 1000
         hour = value.hour | 0x80    # for some unknown reasons hour has to be bit-or'ed with 0x80
         pfield += cls._struct.pack(hour, value.minute, millisecond)
         return pfield
@@ -479,7 +479,7 @@ class Timestamp(Type):
                 value = datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f")
             else:
                 value = datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
-        millisecond = int(round(value.second * 1000 + value.microsecond / 1000.))
+        millisecond = value.second * 1000 + value.microsecond // 1000
         year = value.year | 0x8000  # for some unknown reasons year has to be bit-or'ed with 0x8000
         month = value.month - 1     # for some unknown reasons HANA counts months starting from zero
         hour = value.hour | 0x80    # for some unknown reasons hour has to be bit-or'ed with 0x80

--- a/tests/types/test_datetime.py
+++ b/tests/types/test_datetime.py
@@ -88,6 +88,8 @@ def test_to_daydate(input, expected):
 @pytest.mark.parametrize("input,expected", [
     (datetime(2014, 8, 25, 9, 47, 3), b'\x10\xDE\x87\x07\x19\x89\x2F\xb8\x0b'),
     (datetime(2014, 8, 25, 9, 47, 3, 2000), b'\x10\xDE\x87\x07\x19\x89\x2F\xba\x0b'),
+    (datetime(2014, 8, 25, 9, 47, 3, 999000), b'\x10\xDE\x87\x07\x19\x89\x2F\x9f\x0f'),
+    (datetime(2014, 8, 25, 9, 47, 3, 999999), b'\x10\xDE\x87\x07\x19\x89\x2F\x9f\x0f'),
     ("2014-08-25 09:47:03", b'\x10\xDE\x87\x07\x19\x89\x2F\xb8\x0b'),
     ("2014-08-25 09:47:03.002000", b'\x10\xDE\x87\x07\x19\x89\x2F\xba\x0b'),
 ])
@@ -106,6 +108,8 @@ def test_pack_date(input, expected):
 @pytest.mark.parametrize("input,expected", [
     (time(9, 47, 3), b'\x0f\x89/\xb8\x0b'),
     (time(9, 47, 3, 2000), b'\x0f\x89\x2F\xba\x0b'),
+    (time(9, 47, 3, 999000), b'\x0f\x89\x2F\x9f\x0f'),
+    (time(9, 47, 3, 999999), b'\x0f\x89\x2F\x9f\x0f'),
     ("9:47:03", b'\x0f\x89/\xb8\x0b'),
     ("9:47:03.002000", b'\x0f\x89\x2F\xba\x0b'),
 ])


### PR DESCRIPTION
This ensures that the value sent to Hana for seconds and milliseconds is in the expected range of 0-59999.

The current implementation computes a value of 60000 for a datetime like `datetime(2016, 11, 2, 10, 10, 59, 999999)` which is rejected by HANA with this message `invalid DATE, TIME or TIMESTAMP value: not a valid millisecond: 60000: type_code=16, index=1`.