### PR TITLE
Ignore PARAMETERMETADATA part while handling an upsert response.

### DIFF
--- a/pyhdb/cursor.py
+++ b/pyhdb/cursor.py
@@ -293,7 +293,7 @@ class Cursor(object):
         for part in parts:
             if part.kind == part_kinds.ROWSAFFECTED:
                 self.rowcount = part.values[0]
-            elif part.kind in (part_kinds.TRANSACTIONFLAGS, part_kinds.STATEMENTCONTEXT):
+            elif part.kind in (part_kinds.TRANSACTIONFLAGS, part_kinds.STATEMENTCONTEXT, part_kinds.PARAMETERMETADATA):
                 pass
             elif part.kind == part_kinds.WRITELOBREPLY:
                 # This part occurrs after lobs have been submitted not at all or only partially during an insert.


### PR DESCRIPTION
Hana (1.00.122) seems to sometimes send a PARAMETERMETADATA part in reply to the execution of a prepared DELETE statement.
So I suggest to ignore this part in the `_handle_upsert()` function.

This is the same thing that have been done for `_handle_select()` in commit 98d08794355b6e0d3c0987b25f35ff759e25b084.
I also don't know if this patch needs to be applied to `_handle_dbproc_call()` which is the last handler of `execute_prepared()`.