### PR TITLE
Add support for TEXT columns

### DIFF
--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -280,4 +280,5 @@ LOB_TYPE_CODE_MAP = {
     type_codes.BLOB: Blob,
     type_codes.CLOB: Clob,
     type_codes.NCLOB: NClob,
+    type_codes.NLOCATOR: NClob
 }

--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -501,7 +501,7 @@ class Parameters(Part):
                 else:
                     pfield = _DataType.prepare(value)
 
-                if type_code in (types.BlobType.type_code, types.ClobType.type_code, types.NClobType.type_code):
+                if type_code in pyhdb.protocol.lobs.LOB_TYPE_CODE_MAP:
                     # In case of value being a lob its actual data is not yet included in 'pfield' generated above.
                     # Instead the lob data needs to be appended at the end of the packed row data.
                     # Memorize the position of the lob header data (the 'pfield'):


### PR DESCRIPTION
See issue https://github.com/SAP/PyHDB/issues/72.

`TEXT` columns seem to use the `NLOCATOR` (32) data type internally which behaves just like `NCLOB`.