### PR TITLE
Append local buffer only if value is present instead exception during…

### DIFF
--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -506,11 +506,12 @@ class Parameters(Part):
                     # Instead the lob data needs to be appended at the end of the packed row data.
                     # Memorize the position of the lob header data (the 'pfield'):
                     lob_header_pos = payload.tell()
-                    lob_buffer = LobBuffer(value, _DataType, lob_header_pos)
-                    # Add length of lob data to the sum so we can see whether all data fits into a segment below:
-                    row_lob_size_sum += lob_buffer.encoded_lob_size
-                    # Append lob data so it can be appended once all data for the row is packed:
-                    row_lobs.append(lob_buffer)
+                    if value:
+                        lob_buffer = LobBuffer(value, _DataType, lob_header_pos)
+                        # Add length of lob data to the sum so we can see whether all data fits into a segment below:
+                        row_lob_size_sum += lob_buffer.encoded_lob_size
+                        # Append lob data so it can be appended once all data for the row is packed:
+                        row_lobs.append(lob_buffer)
 
                 payload.write(pfield)
 


### PR DESCRIPTION
```
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 874, in commit
    self.transaction.commit()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 461, in commit
    self._prepare_impl()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 441, in _prepare_impl
    self.session.flush()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 2139, in flush
    self._flush(objects)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 2259, in _flush
    transaction.rollback(_capture_exception=True)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/util/langhelpers.py", line 60, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/util/compat.py", line 187, in reraise
    raise value
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 2223, in _flush
    flush_context.execute()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/unitofwork.py", line 389, in execute
    rec.execute(self)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/unitofwork.py", line 548, in execute
    uow
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/persistence.py", line 181, in save_obj
    mapper, table, insert)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/persistence.py", line 835, in _emit_insert_statements
    execute(statement, params)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 945, in execute
    return meth(self, multiparams, params)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/sql/elements.py", line 263, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1053, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1189, in _execute_context
    context)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1396, in _handle_dbapi_exception
    util.reraise(*exc_info)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/util/compat.py", line 187, in reraise
    raise value
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/cursor.py", line 260, in execute
    self.executemany(statement, parameters=[parameters])
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/cursor.py", line 284, in executemany
    self.execute_prepared(prepared_statement, parameters)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/cursor.py", line 189, in execute_prepared
    reply = self.connection.send_request(request)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/connection.py", line 83, in send_request
    payload = message.pack()  # obtain BytesIO instance
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/message.py", line 55, in pack
    self.build_payload(payload)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/message.py", line 45, in build_payload
    segment.pack(payload, commit=self.autocommit)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/segments.py", line 94, in pack
    self.build_payload(payload)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/segments.py", line 80, in build_payload
    part_payload = part.pack(remaining_size)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/parts.py", line 103, in pack
    arguments_count, payload = self.pack_data(remaining_size - self.header_size)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/parts.py", line 509, in pack_data
    lob_buffer = LobBuffer(value, _DataType, lob_header_pos)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/parts.py", line 448, in __init__
    enc_data = orig_data.encode()
AttributeError: 'NoneType' object has no attribute 'encode'
```

**after**

```
    db.commit()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/scoping.py", line 157, in do
    return getattr(self.registry(), name)(*args, **kwargs)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 874, in commit
    self.transaction.commit()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 461, in commit
    self._prepare_impl()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 441, in _prepare_impl
    self.session.flush()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 2139, in flush
    self._flush(objects)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 2259, in _flush
    transaction.rollback(_capture_exception=True)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/util/langhelpers.py", line 60, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/util/compat.py", line 187, in reraise
    raise value
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/session.py", line 2223, in _flush
    flush_context.execute()
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/unitofwork.py", line 389, in execute
    rec.execute(self)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/unitofwork.py", line 548, in execute
    uow
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/persistence.py", line 181, in save_obj
    mapper, table, insert)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/orm/persistence.py", line 835, in _emit_insert_statements
    execute(statement, params)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 945, in execute
    return meth(self, multiparams, params)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/sql/elements.py", line 263, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1053, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1189, in _execute_context
    context)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1393, in _handle_dbapi_exception
    exc_info
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/util/compat.py", line 203, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/util/compat.py", line 186, in reraise
    raise value.with_traceback(tb)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/cursor.py", line 260, in execute
    self.executemany(statement, parameters=[parameters])
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/cursor.py", line 284, in executemany
    self.execute_prepared(prepared_statement, parameters)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/cursor.py", line 189, in execute_prepared
    reply = self.connection.send_request(request)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/connection.py", line 84, in send_request
    return self.__send_message_recv_reply(payload.getvalue())
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/connection.py", line 124, in __send_message_recv_reply
    return ReplyMessage.unpack_reply(header, payload)
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/message.py", line 92, in unpack_reply
    segments=tuple(ReplySegment.unpack_from(payload, expected_segments=header.num_segments)),
  File "/Users/michaelkuty/projects/stories/lib/python3.5/site-packages/pyhdb/protocol/segments.py", line 152, in unpack_from
    raise error.parts[0].errors[0]
sqlalchemy.exc.DatabaseError: (pyhdb.exceptions.DatabaseError) inserted value too large for column: Stories [SQL: 'INSERT INTO companies (id, created, updated, extra, name, token) VALUES (?, ?, ?, ?, ?, ?)'] [parameters: (23, datetime.datetime(2017, 3, 14, 0, 27, 19, 887477), datetime.datetime(2017, 3, 14, 0, 27, 19, 887494), '{}', 'Stories', None)]
```