### PR TITLE
Catch socket errors and reraise as pyhdb error

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -15,10 +15,13 @@
 # Test additional features of pyhdb.Connection
 
 import os
-import pytest
+import socket
 
 from pyhdb.connection import Connection
+from pyhdb.exceptions import OperationalError
+import mock
 import pyhdb
+import pytest
 
 
 @pytest.mark.hanatest
@@ -63,3 +66,11 @@ def test_make_connection_from_pytest_ini():
     if not os.path.isfile('pytest.ini'):
         pytest.skip("Requires pytest.ini file")
     connection = pyhdb.connect.from_ini('pytest.ini')
+
+
+@mock.patch.object(socket, "create_connection")
+def test_connection_refused(mock_socket):
+    mock_socket.side_effect = socket.error("TEST ERROR")
+    with pytest.raises(OperationalError) as e:
+        pyhdb.connect("localhost", 30015, "Fuu", "Bar")
+    assert str(e.value) == "TEST ERROR"


### PR DESCRIPTION
Catch socket errors which occur when trying to connect to hana.
Then reraise them as a pyhdb error.

Makes it possible to catch all pyhdb exception with one class.