### PR TITLE
Let fetch return resultRow object

### DIFF
--- a/pyhdb/resultrow.py
+++ b/pyhdb/resultrow.py
@@ -1,0 +1,59 @@
+import types
+
+class ResultRow(object):
+    """
+    Result Row returned by fetch*()
+    """
+    def __init__(self, column_names=(), column_values=()):
+        self.__update(column_names, column_values)
+
+    def __repr__(self):
+        return str(self.column_values)
+
+    def __update(self, column_names, column_values):
+        self.column_names = list(column_names)
+        self.column_values = column_values
+
+    def __setitem__(self, key, value):
+        if type(key) == types.IntType:
+            self.column_values[key] = value
+        elif type(key) == types.StringType:
+            try:
+                ind = self.column_names.index(key.upper())
+                self.column_values[ind] = value
+            except ValueError:
+                raise KeyError("\'%s\' is not found" % key.upper())
+        else:
+            raise TypeError("%s is not supported as a key" % str(type(key)))
+
+    def __getitem__(self, key):
+        if type(key) == types.IntType:
+            return self.column_values[key]
+        elif type(key) == types.SliceType:
+            return self.column_values[key.start:key.stop:key.step]
+        elif type(key) == types.StringType:
+            try:
+                ind = self.column_names.index(key.upper())
+                return self.column_values[ind]
+            except ValueError:
+                raise KeyError("\'%s\' is not found" % key.upper())
+        else:
+            raise TypeError("%s is not supported as a key" % str(type(key)))
+
+    def __len__(self):
+        return len(self.column_values)
+
+
+    def __iter__(self):
+        for value in self.column_values:
+            yield value
+
+    def __cmp__(self, other):
+        if not isinstance(other, ResultRow):
+            raise TypeError("%s is not a result row fetched by pyhdb" % (other,))
+        if self.column_values < other.column_values:
+            return -1
+        elif self.column_values == other.column_values:
+            return 0
+        else:  # self > other
+            return 1

--- a/tests/test_call_stored.py
+++ b/tests/test_call_stored.py
@@ -19,7 +19,7 @@ import pytest
 import tests.helper
 
 from tests.helper import procedure_add2_fixture, procedure_with_result_fixture
-
+from pyhdb.resultrow import ResultRow
 # #############################################################################################################
 #                         Basic Stored Procedure test
 # #############################################################################################################
@@ -36,7 +36,7 @@ def test_PROC_ADD2(connection, procedure_add2_fixture):
     ps = cursor.get_prepared_statement(psid)
     cursor.execute_prepared(ps, [params])
     result = cursor.fetchall()
-    assert result == [(7, 'A')]
+    assert result == [ResultRow((), (7, 'A'))]
 
 @pytest.mark.hanatest
 def test_proc_with_results(connection, procedure_with_result_fixture):
@@ -50,6 +50,6 @@ def test_proc_with_results(connection, procedure_with_result_fixture):
     cursor.execute_prepared(ps, [{'OUTVAR': 0}])
     result = cursor.fetchall()
 
-    assert result == [(2015,)]
+    assert result == [ResultRow((), (2015,))]
 
     cursor.close()

--- a/tests/test_dummy_sql.py
+++ b/tests/test_dummy_sql.py
@@ -17,7 +17,7 @@ import datetime
 from decimal import Decimal, getcontext
 
 import pytest
-
+from pyhdb.resultrow import ResultRow
 
 @pytest.mark.hanatest
 def test_dummy_sql_int(connection):
@@ -25,7 +25,7 @@ def test_dummy_sql_int(connection):
     cursor.execute("SELECT 1 FROM DUMMY")
 
     result = cursor.fetchone()
-    assert result == (1,)
+    assert result == ResultRow((), (1,))
 
 
 @pytest.mark.hanatest
@@ -36,7 +36,7 @@ def test_dummy_sql_decimal(connection):
     cursor.execute("SELECT -312313212312321.1245678910111213142 FROM DUMMY")
 
     result = cursor.fetchone()
-    assert result == (Decimal('-312313212312321.1245678910111213142'),)
+    assert result == ResultRow((), (Decimal('-312313212312321.1245678910111213142'),))
 
 
 @pytest.mark.hanatest
@@ -45,18 +45,18 @@ def test_dummy_sql_string(connection):
     cursor.execute("SELECT 'Hello World' FROM DUMMY")
 
     result = cursor.fetchone()
-    assert result == ("Hello World",)
+    assert result == ResultRow((), ("Hello World",))
 
 
 @pytest.mark.hanatest
 def test_dummy_sql_long_string(connection):
-    test_string = '%030x' % random.randrange(16**300)
+    test_string = '%030x' % random.randrange(16 ** 300)
 
     cursor = connection.cursor()
     cursor.execute("SELECT '%s' FROM DUMMY" % test_string)
 
     result = cursor.fetchone()
-    assert result == (test_string,)
+    assert result == ResultRow((), (test_string,))
 
 
 @pytest.mark.hanatest
@@ -65,7 +65,7 @@ def test_dummy_sql_binary(connection):
     cursor.execute("SELECT X'FF00FFA3B5' FROM DUMMY")
 
     result = cursor.fetchone()
-    assert result == (b"\xFF\x00\xFF\xA3\xB5",)
+    assert result == ResultRow((), (b"\xFF\x00\xFF\xA3\xB5",))
 
 
 @pytest.mark.hanatest

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -16,7 +16,7 @@ import pytest
 
 import pyhdb
 import tests.helper
-
+from pyhdb.resultrow import ResultRow
 TABLE = 'PYHDB_TEST_1'
 TABLE_FIELDS = 'TEST VARCHAR(255)'
 
@@ -44,7 +44,7 @@ class TestIsolationBetweenConnections(object):
             'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor1.fetchall() == [('connection_1',)]
+        assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
 
         cursor2 = connection_2.cursor()
         cursor2.execute("SELECT * FROM PYHDB_TEST_1")
@@ -53,7 +53,7 @@ class TestIsolationBetweenConnections(object):
         connection_1.commit()
 
         cursor2.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor2.fetchall() == [('connection_1',)]
+        assert cursor2.fetchall() == [ResultRow((), ('connection_1',))]
 
     def test_rollback(self, request, hana_system, test_table):
         connection_1 = pyhdb.connect(*hana_system)
@@ -69,7 +69,7 @@ class TestIsolationBetweenConnections(object):
             'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor1.fetchall() == [('connection_1',)]
+        assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
 
         cursor2 = connection_2.cursor()
         cursor2.execute("SELECT * FROM PYHDB_TEST_1")
@@ -94,11 +94,11 @@ class TestIsolationBetweenConnections(object):
             'INSERT INTO PYHDB_TEST_1 VALUES(%s)', ('connection_1',)
         )
         cursor1.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor1.fetchall() == [('connection_1',)]
+        assert cursor1.fetchall() == [ResultRow((), ('connection_1',))]
 
         cursor2 = connection_2.cursor()
         cursor2.execute("SELECT * FROM PYHDB_TEST_1")
-        assert cursor2.fetchall() == [('connection_1',)]
+        assert cursor2.fetchall() == [ResultRow((), ('connection_1',))]
 
     def test_select_for_update(self, connection, test_table):
         cursor = connection.cursor()
@@ -106,5 +106,5 @@ class TestIsolationBetweenConnections(object):
         connection.commit()
 
         cursor.execute("SELECT * FROM PYHDB_TEST_1 FOR UPDATE")
-        assert cursor.fetchall() == [('test',)]
+        assert cursor.fetchall() == [ResultRow((), ('test',))]
 


### PR DESCRIPTION
ResultRow objects enables one to acces elements either using indices or using their column names.
It does not break the dbapi specification, because it can be used as a sequence.

Accessing the result using column names is a great feature, because accessing the sequence using indices is error prone, e.g. when adding a column in the middle of the query, all indices have to be adapted, this can lead to errors easily.
