### PR TITLE
Fixed parameters tuple access with unicode index

### DIFF
--- a/pyhdb/cursor.py
+++ b/pyhdb/cursor.py
@@ -99,7 +99,7 @@ class PreparedStatement(object):
         if len(parameters) != len(self._params_metadata):
             raise ProgrammingError("Prepared statement parameters expected %d supplied %d." %
                                    (len(self._params_metadata), len(parameters)))
-        row_params = [self.ParamTuple(p.id, p.datatype, p.length, parameters[p.id]) for p in self._params_metadata]
+        row_params = [self.ParamTuple(p.id, p.datatype, p.length, parameters[i]) for i, p in enumerate(self._params_metadata)]
         self._iter_row_count += 1
         return row_params
 
@@ -293,7 +293,7 @@ class Cursor(object):
         for part in parts:
             if part.kind == part_kinds.ROWSAFFECTED:
                 self.rowcount = part.values[0]
-            elif part.kind in (part_kinds.TRANSACTIONFLAGS, part_kinds.STATEMENTCONTEXT):
+            elif part.kind in (part_kinds.TRANSACTIONFLAGS, part_kinds.STATEMENTCONTEXT, part_kinds.PARAMETERMETADATA):
                 pass
             elif part.kind == part_kinds.WRITELOBREPLY:
                 # This part occurrs after lobs have been submitted not at all or only partially during an insert.


### PR DESCRIPTION
On executing context for a prepared statement which calls parameterized
functions, stored procedures, etc. HANA returns parametermetadata
containing the parameters name as id. On execution cursor.py used this
id for index access to the parameters tuple. Now an enumeration is used
to get the position of the current parameter/parametermetadata and for
access to the paramters tuple.

Executing a prepared statement can return parametermetadata which led
to "unknwon part kind" errors. The parameterdataset is now recognized
as valid part kind (but is ignored).