### PR TITLE
Change encoding for NClob type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ python:
   - "3.5"
 install:
   - pip install -e .
-  - pip install chardet
 script:
   - py.test -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ python:
   - "3.5"
 install:
   - pip install -e .
+  - pip install chardet
 script:
   - py.test -v

--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -257,7 +257,7 @@ class Clob(_CharLob):
 class NClob(_CharLob):
     """Instance of this class will be returned for a NCLOB object in a db result"""
     type_code = type_codes.NCLOB
-    encoding = 'utf8'
+    encoding = 'latin-1'
 
     def __unicode__(self):
         """Convert lob into its unicode format"""

--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -20,6 +20,7 @@ from pyhdb.protocol.segments import RequestSegment
 from pyhdb.protocol.constants import message_types, type_codes
 from pyhdb.protocol.parts import ReadLobRequest
 from pyhdb.compat import PY2, PY3, byte_type
+from pyhdb import cesu8
 
 if PY2:
     # Depending on the Python version we use different underlying containers for CLOB strings
@@ -257,7 +258,7 @@ class Clob(_CharLob):
 class NClob(_CharLob):
     """Instance of this class will be returned for a NCLOB object in a db result"""
     type_code = type_codes.NCLOB
-    encoding = 'utf8'
+    encoding = cesu8
 
     def __unicode__(self):
         """Convert lob into its unicode format"""
@@ -269,19 +270,9 @@ class NClob(_CharLob):
 
         if PY2 and isinstance(init_value, str):
             # io.String() only accepts unicode values, so do necessary conversion here:
-            try:
-                init_value = init_value.decode(self.encoding)
-            except UnicodeDecodeError as e:
-                logger.warning('Decoding failed: %s' % str(e))
-                logger.warning('Will proceed with decoding, but errored characters will be ignored')
-                init_value = init_value.decode(self.encoding, errors='ignore')
+            init_value = cesu8.decode(init_value)
         if PY3 and isinstance(init_value, byte_type):
-            try:
-                init_value = init_value.decode(self.encoding)
-            except UnicodeDecodeError as e:
-                logger.warning('Decoding failed: %s' % str(e))
-                logger.warning('Will proceed with decoding, but errored characters will be ignored')
-                init_value = init_value.decode(self.encoding, errors='ignore')
+            init_value = cesu8.decode(init_value)
 
         return io.StringIO(init_value)
 

--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -234,7 +234,7 @@ class Clob(_CharLob):
 
     def __unicode__(self):
         """Convert lob into its unicode format"""
-        return self.data.getvalue().decode(self.encoding, errors='ignore')
+        return self.data.getvalue().decode(self.encoding)
 
     def _init_io_container(self, init_value):
         """Initialize container to hold lob data.

--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -14,7 +14,6 @@
 
 import io
 import logging
-import chardet
 from pyhdb.protocol.headers import ReadLobHeader
 from pyhdb.protocol.message import RequestMessage
 from pyhdb.protocol.segments import RequestSegment
@@ -77,7 +76,7 @@ class Lob(object):
 
     @classmethod
     def _decode_lob_data(cls, payload_data):
-        return payload_data.decode(cls.encoding) if cls.encoding else payload_data
+        return payload_data.decode(cls.encoding, errors='ignore') if cls.encoding else payload_data
 
     def __init__(self, init_value='', lob_header=None, connection=None):
         self.data = self._init_io_container(init_value)
@@ -234,7 +233,7 @@ class Clob(_CharLob):
 
     def __unicode__(self):
         """Convert lob into its unicode format"""
-        return self.data.getvalue().decode(self.encoding)
+        return self.data.getvalue().decode(self.encoding, errors='ignore')
 
     def _init_io_container(self, init_value):
         """Initialize container to hold lob data.
@@ -258,7 +257,7 @@ class Clob(_CharLob):
 class NClob(_CharLob):
     """Instance of this class will be returned for a NCLOB object in a db result"""
     type_code = type_codes.NCLOB
-    encoding = None
+    encoding = 'utf8'
 
     def __unicode__(self):
         """Convert lob into its unicode format"""
@@ -267,12 +266,12 @@ class NClob(_CharLob):
     def _init_io_container(self, init_value):
         if isinstance(init_value, io.StringIO):
             return init_value
-        encoding = chardet.detect(init_value)['encoding']
+
         if PY2 and isinstance(init_value, str):
             # io.String() only accepts unicode values, so do necessary conversion here:
-            init_value = init_value.decode(self.encoding)
+            init_value = init_value.decode(self.encoding, errors='ignore')
         if PY3 and isinstance(init_value, byte_type):
-            init_value = init_value.decode(self.encoding)
+            init_value = init_value.decode(self.encoding, errors='ignore')
 
         return io.StringIO(init_value)
 

--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -76,7 +76,7 @@ class Lob(object):
 
     @classmethod
     def _decode_lob_data(cls, payload_data):
-        return payload_data.decode(cls.encoding, errors='ignore') if cls.encoding else payload_data
+        return payload_data.decode(cls.encoding) if cls.encoding else payload_data
 
     def __init__(self, init_value='', lob_header=None, connection=None):
         self.data = self._init_io_container(init_value)
@@ -269,9 +269,19 @@ class NClob(_CharLob):
 
         if PY2 and isinstance(init_value, str):
             # io.String() only accepts unicode values, so do necessary conversion here:
-            init_value = init_value.decode(self.encoding, errors='ignore')
+            try:
+                init_value = init_value.decode(self.encoding)
+            except UnicodeDecodeError as e:
+                logger.warning('Decoding failed: %s' % str(e))
+                logger.warning('Will proceed with decoding, but errored characters will be ignored')
+                init_value = init_value.decode(self.encoding, errors='ignore')
         if PY3 and isinstance(init_value, byte_type):
-            init_value = init_value.decode(self.encoding, errors='ignore')
+            try:
+                init_value = init_value.decode(self.encoding)
+            except UnicodeDecodeError as e:
+                logger.warning('Decoding failed: %s' % str(e))
+                logger.warning('Will proceed with decoding, but errored characters will be ignored')
+                init_value = init_value.decode(self.encoding, errors='ignore')
 
         return io.StringIO(init_value)
 

--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -14,6 +14,7 @@
 
 import io
 import logging
+import chardet
 from pyhdb.protocol.headers import ReadLobHeader
 from pyhdb.protocol.message import RequestMessage
 from pyhdb.protocol.segments import RequestSegment
@@ -257,7 +258,7 @@ class Clob(_CharLob):
 class NClob(_CharLob):
     """Instance of this class will be returned for a NCLOB object in a db result"""
     type_code = type_codes.NCLOB
-    encoding = 'latin-1'
+    encoding = None
 
     def __unicode__(self):
         """Convert lob into its unicode format"""
@@ -266,7 +267,7 @@ class NClob(_CharLob):
     def _init_io_container(self, init_value):
         if isinstance(init_value, io.StringIO):
             return init_value
-
+        encoding = chardet.detect(init_value)['encoding']
         if PY2 and isinstance(init_value, str):
             # io.String() only accepts unicode values, so do necessary conversion here:
             init_value = init_value.decode(self.encoding)


### PR DESCRIPTION
On certain systems (primarily Windows) encoding NClob returns as `utf8` can run into errors when the return contains special characters (Such as an í).