### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/pyhdb/protocol/lobs.py
+++ b/pyhdb/protocol/lobs.py
@@ -73,10 +73,17 @@ class Lob(object):
     def from_payload(cls, payload_data, lob_header, connection):
         enc_payload_data = cls._decode_lob_data(payload_data)
         return cls(enc_payload_data, lob_header, connection)
-
+    
     @classmethod
     def _decode_lob_data(cls, payload_data):
-        return payload_data.decode(cls.encoding) if cls.encoding else payload_data
+        try:
+            tmp = payload_data.decode(cls.encoding) if cls.encoding else payload_data
+        except Exception:
+            # make same length of input
+            tmp = ''.join([' ' for _ in range(len(payload_data))]).encode()
+            tmp = tmp.decode(cls.encoding) if cls.encoding else payload_data
+        return tmp
+
 
     def __init__(self, init_value='', lob_header=None, connection=None):
         self.data = self._init_io_container(init_value)


### PR DESCRIPTION
Issue:
When there are some data like emoji which can not decode by 'utf-8', it could cause such error:

~\AppData\Local\Continuum\anaconda3\envs\work\lib\site-packages\pyhdb\protocol\lobs.py in _decode_lob_data(cls, payload_data)
     77     @classmethod
     78     def _decode_lob_data(cls, payload_data):
---> 79         return payload_data.decode(cls.encoding) if cls.encoding else payload_data
     80 
     81     def __init__(self, init_value='', lob_header=None, connection=None):

UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 37: invalid continuation byte

The problem here is the previous function assumes data is pure bytes type encoding from str, however it may happen that the data is not clean. 

Solution:
If the data is not clean or can not decode to str, then return it empty with same length (or better solution? remove it?)