### PR TITLE
Fixes bug in Class Error on unpacking data

### DIFF
--- a/pyhdb/protocol/parts.py
+++ b/pyhdb/protocol/parts.py
@@ -248,15 +248,13 @@ class Error(Part):
     def unpack_data(cls, argument_count, payload):
         errors = []
         for _ in iter_range(argument_count):
-            buff = payload.read(cls.part_struct.size)
-            if len(buff) == cls.part_struct.size:
-                code, position, textlength, level, sqlstate = cls.part_struct.unpack(buff)
-                errortext = payload.read(textlength+4)[0:-4].decode('utf-8', 'ignore')
-                if code == 301:
-                    # Unique constraint violated
-                    errors.append(IntegrityError(errortext, code))
-                else:
-                    errors.append(DatabaseError(errortext, code))
+            code, position, textlength, level, sqlstate = cls.part_struct.unpack(payload.read(cls.part_struct.size))
+            errortext = payload.read(textlength+4)[0:-4].decode('utf-8', 'ignore')
+            if code == 301:
+                # Unique constraint violated
+                errors.append(IntegrityError(errortext, code))
+            else:
+                errors.append(DatabaseError(errortext, code))
         return tuple(errors),
 
 

--- a/pyhdb/protocol/segments.py
+++ b/pyhdb/protocol/segments.py
@@ -147,7 +147,7 @@ class ReplySegment(BaseSegment):
             elif segment_header.segment_kind == segment_kinds.ERROR:
                 error = segment
                 if error.parts[0].kind == part_kinds.ROWSAFFECTED:
-                    raise Exception("Rows affected %s" % (error.parts[0].values,))
+                    raise Exception("Rows affected %s" % (error.parts[1].errors,))
                 elif error.parts[0].kind == part_kinds.ERROR:
                     raise error.parts[0].errors[0]
             else:


### PR DESCRIPTION
Issue:
On insert data when unique constraint violated:

line 92, in unpack_reply
    segments=tuple(ReplySegment.unpack_from(payload, expected_segments=header.num_segments)),
  File "C:\Users\Claudio\AppData\Local\Programs\Python\Python37\lib\site-packages\pyhdb\protocol\segments.py", line 142, in unpack_from
    parts = tuple(Part.unpack_from(segment_payload, expected_parts=segment_header.num_parts))
  File "C:\Users\Claudio\AppData\Local\Programs\Python\Python37\lib\site-packages\pyhdb\protocol\parts.py", line 146, in unpack_from
    init_arguments = _PartClass.unpack_data(part_header.argument_count, part_payload)
  File "C:\Users\Claudio\AppData\Local\Programs\Python\Python37\lib\site-packages\pyhdb\protocol\parts.py", line 252, in unpack_data
    errortext = payload.read(textlength).decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 12: invalid start byte

Solution:
Increase 4 bytes on error text buffer size.
Deleted error text buffer char delimiters.
Ignore error handling scheme.